### PR TITLE
feat: add mapping aliases & improve nuxt module

### DIFF
--- a/docs/nuxt.md
+++ b/docs/nuxt.md
@@ -27,6 +27,11 @@ _string_ ( default: `store`)
 
 Customise the folder containing your state, actions and getters files
 
+#### `disableVuex`
+_boolean_ ( default: `true`)
+
+Set this to `false` if you want Vuex and vue-stator to be both included in your project.
+
 ## Global state
 
 There's only one state tree definition in `vue-stator`.

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -55,6 +55,8 @@ export default async function NuxtStatorModule (options) {
     ...this.options.stator
   }
 
+  const disableStore = 'disableVuex' in options ? options.disableVuex : true
+
   const baseDirName = options.baseDir || 'store'
   const baseDir = path.join(this.options.srcDir, baseDirName)
 
@@ -70,7 +72,7 @@ export default async function NuxtStatorModule (options) {
   const hasGlobalGetters = files.includes('getters.js')
 
   // Disable default Vuex store (options.features only exists in Nuxt v2.10+)
-  if (this.options.features) {
+  if (this.options.features && disableStore) {
     this.options.features.store = false
   }
 

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -21,6 +21,7 @@ export default function NuxtStatorModule (options) {
 
   let statorModules
   this.nuxt.hook('builder:prepared', async (builder) => {
+    // this is copied from nuxt/builder/builder.js:resolveStore
     statorModules = (await builder.resolveRelative(statorDir))
       .sort(({ src: p1 }, { src: p2 }) => {
         // modules are sorted from low to high priority (for overwriting properties)

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -1,75 +1,13 @@
-import fs from 'fs'
 import path from 'path'
-import { promisify } from 'util'
-import consola from 'consola'
 
-const readDir = promisify(fs.readdir)
-const logger = consola.withScope('vue-stator')
-
-function exists (p) {
-  return new Promise((resolve, reject) => {
-    fs.access(p, fs.constants.F_OK, (err) => {
-      if (err) {
-        resolve(false)
-        return
-      }
-
-      resolve(true)
-    })
-  })
-}
-
-async function loadStatorModules (baseDir) {
-  // TODO: handle error
-  const files = await readDir(baseDir)
-
-  const modules = await Promise.all(files
-    .filter(modulePath => !(['actions.js', 'state.js', 'getters.js', 'index.js'].includes(modulePath)))
-    .map(async (modulePath) => {
-      const { name: namespace } = path.parse(modulePath)
-
-      if (modulePath.endsWith('.js')) {
-        return {
-          namespace,
-          actions: modulePath
-        }
-      }
-
-      let statorModule
-      for (const type of ['actions', 'getters']) {
-        if (await exists(path.join(baseDir, modulePath, `${type}.js`))) {
-          statorModule = statorModule || { namespace }
-          statorModule[type] = path.join(modulePath, `${type}.js`)
-        }
-      }
-
-      return statorModule
-    }))
-
-  return [modules.filter(Boolean), files]
-}
-
-export default async function NuxtStatorModule (options) {
+export default function NuxtStatorModule (options) {
   options = {
     ...options,
     ...this.options.stator
   }
 
+  const statorDir = options.baseDir || 'store'
   const disableStore = 'disableVuex' in options ? options.disableVuex : true
-
-  const baseDirName = options.baseDir || 'store'
-  const baseDir = path.join(this.options.srcDir, baseDirName)
-
-  if (!await exists(baseDir)) {
-    logger.warn(`Folder '~/${path.relative(this.nuxt.options.srcDir, baseDir)}' does not exists, vue-stator will not be enabled`)
-    return
-  }
-
-  const [statorModules, files] = await loadStatorModules(baseDir)
-
-  const hasState = files.includes('state.js')
-  const hasGlobalActions = files.includes('actions.js')
-  const hasGlobalGetters = files.includes('getters.js')
 
   // Disable default Vuex store (options.features only exists in Nuxt v2.10+)
   if (this.options.features && disableStore) {
@@ -78,16 +16,25 @@ export default async function NuxtStatorModule (options) {
 
   this.addPlugin({
     src: path.resolve(__dirname, 'plugin.js'),
-    fileName: 'vue-stator.js',
-    options: {
-      isSPA: this.options.mode === 'spa',
-      baseDir: baseDirName,
-      localStorage: options.localStorage,
-      sessionStorage: options.sessionStorage,
-      statorModules,
-      hasState,
-      hasGlobalActions,
-      hasGlobalGetters
-    }
+    fileName: 'vue-stator.js'
+  })
+
+  let statorModules
+  this.nuxt.hook('builder:prepared', async (builder) => {
+    statorModules = (await builder.resolveRelative(statorDir))
+      .sort(({ src: p1 }, { src: p2 }) => {
+        // modules are sorted from low to high priority (for overwriting properties)
+        let res = p1.split('/').length - p2.split('/').length
+        if (res === 0 && p1.includes('/index.')) {
+          res = -1
+        } else if (res === 0 && p2.includes('/index.')) {
+          res = 1
+        }
+        return res
+      })
+  })
+
+  this.nuxt.hook('build:templates', ({ templateVars }) => {
+    templateVars.statorModules = statorModules
   })
 }

--- a/nuxt/plugin.js
+++ b/nuxt/plugin.js
@@ -78,8 +78,9 @@ void (function updateModules () {
 })()
 
 // createStore
-export const createStore = store instanceof Function ? store : () => {
+export const createStore = store instanceof Function ? store : (context) => {
   return createStator(Object.assign({
+    context, // vue-stator feature
     strict: (process.env.NODE_ENV !== 'production')
   }, store))
 }

--- a/nuxt/plugin.js
+++ b/nuxt/plugin.js
@@ -1,74 +1,13 @@
 import Vue from 'vue'
 import {
   plugin as VueStator,
-  createStore
-} from 'vue-stator' ///dist/vue-stator.esm.js'
+  createStore as createStator
+} from 'vue-stator'
 
 Vue.use(VueStator)
 
-<% if (options.hasState) { %>import state from '~/<%= options.baseDir %>/state'<% } %>
-<% if (options.hasGlobalActions) { %>import * as actions from '~/<%= options.baseDir %>/actions'<% } %>
-<% if (options.hasGlobalGetters) { %>import * as getters from '~/<%= options.baseDir %>/getters'<% } %>
-<%
-const modules = {}
-for (const statorModule of options.statorModules) {
-  const { namespace, state, getters, actions } = statorModule
-  if (!(state || getters || actions)) {
-    continue
-  }
-
-  modules[namespace] = {}
-
-  if (state) {
-    const importName = `${namespace}State`
-    modules[namespace].state = importName
-
-%>import * as <%= importName %> from '~/<%= options.baseDir %>/<%= state %>'<%
-  }
-
-  if (actions) {
-    const importName = `${namespace}Actions`
-    modules[namespace].actions = importName
-
-%>import * as <%= importName %> from '~/<%= options.baseDir %>/<%= actions %>'<%
-  }
-
-  if (getters) {
-    const importName = `${namespace}Getters`
-    modules[namespace].getters = importName
-
-%>import * as <%= importName %> from '~/<%= options.baseDir %>/<%= getters %>'<%
-  }
-} %>
-
-<% if (!options.hasState) { %>const state = () => ({})<% } %>
-<% if (!options.hasGlobalActions) { %>const actions = {}<% } %>
-<% if (!options.hasGlobalGetters) { %>const getters = {}<% } %>
-
-const modules = {
-  <%= Object.entries(modules).map(([moduleName, module]) =>
-  `${moduleName}: {
-    ${Object.entries(module).map(([key, value]) => `${key}: ${value}`).join('\n    ')}
-  }`).join(',  ') %>
-}
-
-export default async function NuxtStatorPlugin (context, inject) {
-  const hydrate = (initialState) => {
-    return process.client
-      ? <%= options.isSPA ? 'initialState' : 'window.__NUXT__.$state' %>
-      : initialState
-  }
-
-  const initialState = await state(context)
-
-  const stator = createStore({
-    state: () => initialState,
-    context,
-    hydrate,
-    getters,
-    actions,
-    modules
-  })
+export default function NuxtStatorPlugin (context, inject) {
+  const stator = createStore(context)
 
   context.app.stator = stator
 
@@ -80,3 +19,178 @@ export default async function NuxtStatorPlugin (context, inject) {
     context.ssrContext.nuxt.$state = context.$state
   }
 }
+
+<%
+storeModules = statorModules
+
+/*****************************************************************/
+/* below is directly copied from nuxt/vue-app/templates/store.js */
+/*            changes/additions are commented                    */
+/*****************************************************************/
+
+const willResolveStoreModules = storeModules.some(s => s.src.indexOf('index.') !== 0)
+if (willResolveStoreModules) { %>
+const VUEX_PROPERTIES = ['state', 'getters', 'actions']
+<% } %>
+let store = {
+  // vue-stator feature
+  hydrate: (initialState) => {
+    return process.client
+      ? <%= nuxtOptions.mode === 'spa' ? 'initialState' : 'window.__NUXT__.$state' %>
+      : initialState
+  }
+  // end vue-stator feature
+}
+
+void (function updateModules () {
+  <% storeModules.some(s => {
+    if(s.src.indexOf('index.') === 0) { %>
+  store = normalizeRoot(require('<%= relativeToBuild(srcDir, dir.store, s.src) %>'), '<%= dir.store %>/<%= s.src %>')
+  <% return true }}) %>
+
+  // If store is an exported method = classic mode (deprecated)
+  <% if (isDev) { %>
+  if (typeof store === 'function') {
+    <%= isTest ? '// eslint-disable-next-line no-console' : '' %>
+    return console.warn('Classic mode for store/ is deprecated and will be removed in Nuxt 3.')
+  }<% } %>
+
+  // Enforce store modules
+  store.modules = store.modules || {}
+
+  <% storeModules.forEach(s => {
+    if(s.src.indexOf('index.') !== 0) { %>
+  resolveStoreModules(require('<%= relativeToBuild(srcDir, dir.store, s.src) %>'), '<%= s.src %>')<% }}) %>
+
+  // If the environment supports hot reloading...
+  <% if (isDev) { %>
+  if (process.client && module.hot) {
+    // Whenever any Vuex module is updated...
+    module.hot.accept([<% storeModules.forEach(s => { %>
+      '<%= relativeToBuild(srcDir, dir.store, s.src) %>',<% }) %>
+    ], () => {
+      // Update `root.modules` with the latest definitions.
+      updateModules()
+      // Trigger a hot update in the store.
+      window.<%= globals.nuxt %>.$store.hotUpdate(store)
+    })
+  }<% } %>
+})()
+
+// createStore
+export const createStore = store instanceof Function ? store : () => {
+  return createStator(Object.assign({
+    strict: (process.env.NODE_ENV !== 'production')
+  }, store))
+}
+
+function normalizeRoot (moduleData, filePath) {
+  moduleData = moduleData.default || moduleData
+
+  if (moduleData.commit) {
+    throw new Error(`[nuxt] ${filePath} should export a method that returns a Vuex instance.`)
+  }
+
+  if (typeof moduleData !== 'function') {
+    // Avoid TypeError: setting a property that has only a getter when overwriting top level keys
+    moduleData = Object.assign({}, moduleData)
+  }
+  return normalizeModule(moduleData, filePath)
+}
+
+function normalizeModule (moduleData, filePath) {
+  if (moduleData.state && typeof moduleData.state !== 'function') {
+    <%= isTest ? '// eslint-disable-next-line no-console' : '' %>
+    console.warn(`'state' should be a method that returns an object in ${filePath}`)
+
+    const state = Object.assign({}, moduleData.state)
+    // Avoid TypeError: setting a property that has only a getter when overwriting top level keys
+    moduleData = Object.assign({}, moduleData, { state: () => state })
+  }
+  return moduleData
+}
+
+<% if (willResolveStoreModules) { %>
+function resolveStoreModules (moduleData, filename) {
+  moduleData = moduleData.default || moduleData
+  // Remove store src + extension (./foo/index.js -> foo/index)
+  const namespace = filename.replace(/\.(<%= extensions %>)$/, '')
+  const namespaces = namespace.split('/')
+  let moduleName = namespaces[namespaces.length - 1]
+  const filePath = `<%= dir.store %>/${filename}`
+
+  moduleData = moduleName === 'state'
+    ? normalizeState(moduleData, filePath)
+    : normalizeModule(moduleData, filePath)
+
+  // If src is a known Vuex property
+  if (VUEX_PROPERTIES.includes(moduleName)) {
+    const property = moduleName
+    const storeModule = getStoreModule(store, namespaces, { isProperty: true })
+
+    // Replace state since it's a function
+    mergeProperty(storeModule, moduleData, property)
+    return
+  }
+
+  // If file is foo/index.js, it should be saved as foo
+  const isIndexModule = (moduleName === 'index')
+  if (isIndexModule) {
+    namespaces.pop()
+    moduleName = namespaces[namespaces.length - 1]
+  }
+
+  const storeModule = getStoreModule(store, namespaces)
+
+  for (const property of VUEX_PROPERTIES) {
+    mergeProperty(storeModule, moduleData[property], property)
+  }
+
+  // special vue-stator feature, default a module export actions
+  if (!VUEX_PROPERTIES.some(prop => storeModule[prop])) {
+    mergeProperty(storeModule, moduleData, 'actions')
+  }
+  // end special vue-stator feature
+
+  if (moduleData.namespaced === false) {
+    delete storeModule.namespaced
+  }
+}
+
+function normalizeState (moduleData, filePath) {
+  if (typeof moduleData !== 'function') {
+    <%= isTest ? '// eslint-disable-next-line no-console' : '' %>
+    console.warn(`${filePath} should export a method that returns an object`)
+    const state = Object.assign({}, moduleData)
+    return () => state
+  }
+  return normalizeModule(moduleData, filePath)
+}
+
+function getStoreModule (storeModule, namespaces, { isProperty = false } = {}) {
+  // If ./mutations.js
+  if (!namespaces.length || (isProperty && namespaces.length === 1)) {
+    return storeModule
+  }
+
+  const namespace = namespaces.shift()
+
+  storeModule.modules[namespace] = storeModule.modules[namespace] || {}
+  storeModule.modules[namespace].namespaced = true
+  storeModule.modules[namespace].modules = storeModule.modules[namespace].modules || {}
+
+  return getStoreModule(storeModule.modules[namespace], namespaces, { isProperty })
+}
+
+function mergeProperty (storeModule, moduleData, property) {
+  if (!moduleData) {
+    return
+  }
+
+  if (property === 'state') {
+    storeModule.state = moduleData || storeModule.state
+  } else {
+    storeModule[property] = Object.assign({}, storeModule[property], moduleData)
+  }
+}
+<% } %>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -15,48 +15,54 @@ export function $delete (...args) {
   Vue.delete(...args)
 }
 
-export function mapState (namespacedProperties) {
+export function map (properties, assignMapping) {
   const mapped = {}
 
-  for (const prop of ensureArray(namespacedProperties)) {
-    mapped[prop] = {
-      get () {
-        return getPropertyByNamespace(this.$state, prop)
-      },
-      set (value) {
-        return setPropertyByNamespace(this.$state, prop, value)
-      }
+  if (typeof properties !== 'object') {
+    properties = ensureArray(properties)
+  }
+
+  if (Array.isArray(properties)) {
+    for (const prop of properties) {
+      mapped[prop] = assignMapping(prop)
     }
+
+    return mapped
+  }
+
+  for (const propName in properties) {
+    mapped[propName] = assignMapping(properties[propName])
   }
 
   return mapped
+}
+
+export function mapState (namespacedProperties) {
+  return map(namespacedProperties, prop => ({
+    get () {
+      return getPropertyByNamespace(this.$state, prop)
+    },
+    set (value) {
+      return setPropertyByNamespace(this.$state, prop, value)
+    }
+  }))
 }
 
 export function mapGetters (namespacedProperties) {
-  const mapped = {}
-
-  for (const prop of ensureArray(namespacedProperties)) {
-    mapped[prop] = function (...args) {
+  return map(namespacedProperties, (prop) => {
+    return function (...args) {
       return getPropertyByNamespace(this.$getters, prop)
     }
-  }
-
-  return mapped
+  })
 }
 
 export function mapActions (namespacedProperties) {
-  const mapped = {}
-
-  for (const prop of ensureArray(namespacedProperties)) {
-    mapped[prop] = function (...args) {
+  return map(namespacedProperties, (prop) => {
+    return function (...args) {
       const action = getPropertyByNamespace(this.$actions, prop)
       if (action) {
         return action(...args)
       }
-
-      // TODO: warn?
     }
-  }
-
-  return mapped
+  })
 }

--- a/test/unit/helpers.test.js
+++ b/test/unit/helpers.test.js
@@ -24,6 +24,43 @@ describe('helpers', () => {
     expect(Vue.delete).toHaveBeenCalledWith(1)
   })
 
+  test('map accepts string arg', () => {
+    jest.spyOn(namespace, 'getPropertyByNamespace').mockImplementation(_ => _)
+    jest.spyOn(namespace, 'setPropertyByNamespace').mockImplementation(_ => _)
+
+    const assigner = jest.fn()
+    const mapped = helpers.map('name', assigner)
+
+    expect(assigner).toHaveBeenCalledTimes(1)
+    expect(assigner).toHaveBeenCalledWith('name')
+    expect(mapped.hasOwnProperty('name')).toBe(true)
+  })
+
+  test('map accepts array arg', () => {
+    jest.spyOn(namespace, 'getPropertyByNamespace').mockImplementation(_ => _)
+    jest.spyOn(namespace, 'setPropertyByNamespace').mockImplementation(_ => _)
+
+    const assigner = jest.fn()
+    const mapped = helpers.map(['name'], assigner)
+
+    expect(assigner).toHaveBeenCalledTimes(1)
+    expect(assigner).toHaveBeenCalledWith('name')
+    expect(mapped.hasOwnProperty('name')).toBe(true)
+  })
+
+  test('map accepts object arg (to support aliasing)', () => {
+    jest.spyOn(namespace, 'getPropertyByNamespace').mockImplementation(_ => _)
+    jest.spyOn(namespace, 'setPropertyByNamespace').mockImplementation(_ => _)
+
+    const assigner = jest.fn()
+    const mapped = helpers.map({ alias: 'name' }, assigner)
+
+    expect(assigner).toHaveBeenCalledTimes(1)
+    expect(assigner).toHaveBeenCalledWith('name')
+    expect(mapped.hasOwnProperty('name')).toBe(false)
+    expect(mapped.hasOwnProperty('alias')).toBe(true)
+  })
+
   test('mapState', () => {
     jest.spyOn(namespace, 'getPropertyByNamespace').mockImplementation(_ => _)
     jest.spyOn(namespace, 'setPropertyByNamespace').mockImplementation(_ => _)


### PR DESCRIPTION
Resolves #7 & #8

The Nuxt.js module is almost useless in v1, so here are some fixes

- add support for aliasing while mapping:
```js
   ...mapState({ alias: 'my/module/state' })
```

- add `disableVuex` option for Nuxt module

- use Nuxt.js Vuex module for resolving & initialization
