### PR TITLE
feat: add mixin to map state by component option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ export function otherAction ({ state }, param) {
 }
 ```
 
-The first parameter is the context (which can be a Vue.js instance or the Nuxt.js
-context object). You can use it to access the global `$state`, `$actions` and
-`$getters`, and in the case of Nuxt.js, also everything in its own context.
+The first argument is the local module context, the store object itself (and root state/getters/actions) is accessible
+from the `this` value within the action. This means that if you need to access the
+global `$state`, `$actions` or `$getters` you can access them using eg `this.$state`
 
 ## Unified state and modularization
 
@@ -55,24 +55,14 @@ and/or actions.
 
 In practice, this just means you can define **module actions** where the first
 argument is a context object containing:
-- _state_: the state for the current vue-stator module
-- _$state_: the root state of the store
-- _getter_: the getters for the current vue-stator module
-- _$getters_: the root getters of the store
-- _actions_: the ctions for the current vue-stator module
-- _$actions_: the root ctions of the store
-
-It will also list all properties that you passed to the context option of the plugin option
+- _state_: the state for the current vue-stator module or the root state
+- _getter_: the getters for the current vue-stator module or the root getters
+- _actions_: the ctions for the current vue-stator module or the root actions
 
 ```js
 import { plugin as VueStator } from 'vue-stator'
 
 Vue.use(VueStator, {
-  context: {
-    suchWow () {
-      return 'much fun'
-    }
-  },
   state: () => ({
     rootKey: 'a',
     auth: {
@@ -83,11 +73,11 @@ Vue.use(VueStator, {
   modules: {
     auth: {
       actions: {
-        login ({ state, $state, suchWow }, user) {
+        login ({ state }, user) {
           state.user = user
           state.loggedIn = false
 
-          $state.rootKey = suchWow()
+          this.$state.rootKey = 'b'
         }
       }
     }
@@ -97,12 +87,12 @@ Vue.use(VueStator, {
 
 Again notice how `state` is a direct reference to `$state.auth`, to recap:
 
-- `$state` is the **the root state**
-- `state` (without leading `$`) is **the state key that matches the module namespace**
+- The `state` property of the first argument is **the state key that matches the module namespace**
+- `this.$state` is the **the root state**
 
-In Nuxt.js, the first argument also gives you access to everything available in
-Nuxt's context, such as `$axios` if you're using `@nuxtjs/axios` or `$http` if
-using `@nuxt/http`.
+In Nuxt.js if you need to access properties from the Nuxt content (e.g. _$axios_ or _$http_),
+then you need to provide the `inject` module option in your `nuxt.config`. See
+our [Nuxt.js docs](./docs/nuxt.md#injecting-properties-into-the-store) for more information
 
 > **Beware**: in Vuex, dispatching actions will always return a `Promise`.
 >

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Vue.use(VueStator, {
 Again notice how `state` is a direct reference to `$state.auth`, to recap:
 
 - `$state` is the **the root state**
-- `state` (without leading `$` is **the state key that matches the module namespace**
+- `state` (without leading `$`) is **the state key that matches the module namespace**
 
 In Nuxt.js, the first argument also gives you access to everything available in
 Nuxt's context, such as `$axios` if you're using `@nuxtjs/axios` or `$http` if

--- a/README.md
+++ b/README.md
@@ -112,6 +112,57 @@ You have access to everything directly in Vue's context though.
 
 That is, you can just reference `$state.something` in your Vue template and it'll work.
 
+### statorMap component option
+
+You can enable a mixin helper by passing `{ mixin: true }` to your plugin options. Instead of calling `mapState` etc in your components you can now just add a `statorMap` option in your component:
+
+```js
+// App.vue
+Vue.use(VueStator, { mixin: true })
+
+// my-component.vue
+<script>
+export default {
+  statorMap: {
+    // omitting the namespace is the default behaviour
+    // set this to false if you dont want to omit the namespace,
+    // then the properties will be available as: this['my/module/nonAliasedKey']
+    //omitNamespace: true,
+    state: {
+      my: {
+        module: {
+          nonAliasedKey: true,
+          aliasedKey: 'theModuleKey'
+        }
+    },
+    getters: [
+      'rootGetter',
+      'my/module/myGetter'
+    ],
+    actions: ['myAction']
+  },
+  mounted () {
+    this.nonAliasedKey
+    this.aliasedKey
+    this.rootGetter
+    this.myGetter
+    this.myAction()
+  }
+}
+</script>
+```
+
+You can also use a function for `statorMap` in case you need to eg map different state for eg Server-side or Client-side
+
+```js
+  statorMap() {
+    if (process.client) {
+      return { ... }
+    }
+    return { ... }
+  }
+```
+
 ## Runtime helpers
 
 `vue-stator` also provides some helper methods to interact with the store more easily.

--- a/docs/nuxt.md
+++ b/docs/nuxt.md
@@ -104,7 +104,7 @@ Because vue-stator runs as a Nuxt.js module and there is no way to hook into Nux
 ### Race condition due to plugin order
 
 The reason we use `Vue.nextTick().then` in the example above is to overcome an issue due to the order in which plugins are loaded.
-We can only inject a property when that property has already bene injected by its corresponding plugin. `Vue.nextTick().then` runs _after_ all the plugin methods have been called.
+We can only inject a property when that property has already been injected by its corresponding plugin. `Vue.nextTick().then` runs _after_ all the plugin methods have been called.
 
 > Note: providing a callback to _Vue.nextTick(callback)_ wont work, we need to use a Promise
 

--- a/docs/nuxt.md
+++ b/docs/nuxt.md
@@ -86,7 +86,7 @@ In a Nuxt.js application with a Vuex-store, Nuxt.js will create the store before
 
 Because vue-stator runs as a Nuxt.js module and there is no way to hook into Nuxt.js's inject method, you need to manually configure which properties you wish to inject into the store
 
-```js`
+```js
   buildModules: [{
     src: 'vue-stator/nuxt',
     options: {

--- a/docs/nuxt.md
+++ b/docs/nuxt.md
@@ -32,6 +32,17 @@ _boolean_ ( default: `true`)
 
 Set this to `false` if you want Vuex and vue-stator to be both included in your project.
 
+#### `inject`
+_Array<string>_ or _Function_
+
+You can either provide an array of context properties which should be injected into the store or provide a function. The injected properties will be made available on the VueStator store which is accessible as the `this` context of an action.
+
+Properties provided by an array will be automatically prefixed with a `$`, use the function syntax if you need more control
+
+The inject method will receive three arguments: the store, the Nuxt.js context and the Vue import. The Vue import is needed due to the method being serialized so you can still use Vue.nextTick
+
+> Note: when providing a function this function will be serialized in to the plugin template. This means you cannot use variables outside of its own scope (hence why Vue is provided as 3rd arg)
+
 ## Global state
 
 There's only one state tree definition in `vue-stator`.
@@ -68,3 +79,33 @@ Since defining actions tends to be more common than defining getters,
 `vue-stator` reserves the `store/<namespace>.js` convention for actions
 only (see previous topic).
 
+
+## Injecting properties into the store
+
+In a Nuxt.js application with a Vuex-store, Nuxt.js will create the store before any plugins are loaded. Then when any plugin injects a property on the context, that property is also set on the Vuex store.
+
+Because vue-stator runs as a Nuxt.js module and there is no way to hook into Nuxt.js's inject method, you need to manually configure which properties you wish to inject into the store
+
+```js`
+  buildModules: [{
+    src: 'vue-stator/nuxt',
+    options: {
+      inject: ['axios'], // quick method of inject $axios
+      inject (stator, context, Vue) { // or use a function to have granular control
+        Vue.nextTick().then(() => {
+          stator.$http = context.$http
+        })
+      }
+    }
+  }],
+
+```
+
+### Race condition due to plugin order
+
+The reason we use `Vue.nextTick().then` in the example above is to overcome an issue due to the order in which plugins are loaded.
+We can only inject a property when that property has already bene injected by its corresponding plugin. `Vue.nextTick().then` runs _after_ all the plugin methods have been called.
+
+> Note: providing a callback to _Vue.nextTick(callback)_ wont work, we need to use a Promise
+
+> Note 2: If a plugin injects properties using nextTick itself, then `Vue.nextTick().then` could not be sufficient

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -16,7 +16,10 @@ export default function NuxtStatorModule (options) {
 
   this.addPlugin({
     src: path.resolve(__dirname, 'plugin.js'),
-    fileName: 'vue-stator.js'
+    fileName: 'vue-stator.js',
+    options: {
+      inject: options.inject
+    }
   })
 
   let statorModules

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,0 +1,87 @@
+import { mapState, mapGetters, mapActions } from './helpers'
+
+function assignComponentOption (option, mapper, mapping, omitNamespace, namespace) {
+  const createNamespace = key => `${namespace || ''}${namespace && key ? '/' : ''}${key || ''}`
+
+  if (Array.isArray(mapping)) {
+    let namespacedMapping
+
+    if (!omitNamespace) {
+      namespacedMapping = mapping.map(createNamespace)
+    } else {
+      namespacedMapping = {}
+
+      for (const key of mapping) {
+        namespacedMapping[key] = createNamespace(key)
+      }
+    }
+
+    Object.assign(option, mapper(namespacedMapping))
+    return
+  }
+
+  if (typeof mapping !== 'object') {
+    // do nothing, dunno what this is
+    return
+  }
+
+  let aliasedMapping
+
+  for (const key in mapping) {
+    if (typeof mapping[key] === 'object') {
+      assignComponentOption(
+        option,
+        mapper,
+        mapping[key],
+        omitNamespace,
+        createNamespace(key)
+      )
+      continue
+    }
+
+    if (mapping[key]) {
+      aliasedMapping = aliasedMapping || {}
+      const aliasedKey = omitNamespace ? key : createNamespace(key)
+      aliasedMapping[aliasedKey] = createNamespace(mapping[key] === true ? aliasedKey : mapping[key])
+    }
+  }
+
+  if (aliasedMapping) {
+    Object.assign(option, mapper(aliasedMapping))
+  }
+}
+
+export default {
+  beforeCreate () {
+    const mapping = this.$options.statorMap
+    if (!mapping) {
+      return
+    }
+
+    const omitNamespace = !('omitNamespace' in mapping) || mapping.omitNamespace
+
+    for (const type in mapping) {
+      const typeMapping = mapping[type]
+
+      let optionKey
+      let mapper
+
+      if (type === 'actions') {
+        optionKey = 'methods'
+        mapper = mapActions
+      } else {
+        optionKey = 'computed'
+        mapper = type === 'state' ? mapState : mapGetters
+      }
+
+      this.$options[optionKey] = this.$options[optionKey] || {}
+
+      assignComponentOption(
+        this.$options[optionKey],
+        mapper,
+        typeMapping,
+        omitNamespace
+      )
+    }
+  }
+}

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,7 +1,7 @@
 import { mapState, mapGetters, mapActions } from './helpers'
 import { callIfFunction } from './utils'
 
-function assignComponentOption (option, mapper, mapping, omitNamespace, namespace) {
+export function assignComponentOption (option, mapper, mapping, omitNamespace, namespace) {
   const createNamespace = key => `${namespace || ''}${namespace && key ? '/' : ''}${key || ''}`
 
   if (Array.isArray(mapping)) {

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -10,7 +10,6 @@ function assignComponentOption (option, mapper, mapping, omitNamespace, namespac
       namespacedMapping = mapping.map(createNamespace)
     } else {
       namespacedMapping = {}
-
       for (const key of mapping) {
         namespacedMapping[key] = createNamespace(key)
       }
@@ -39,11 +38,14 @@ function assignComponentOption (option, mapper, mapping, omitNamespace, namespac
       continue
     }
 
-    if (mapping[key]) {
-      aliasedMapping = aliasedMapping || {}
-      const aliasedKey = omitNamespace ? key : createNamespace(key)
-      aliasedMapping[aliasedKey] = createNamespace(mapping[key] === true ? aliasedKey : mapping[key])
+    if (!mapping[key]) {
+      // ignore values with falsy value
+      continue
     }
+
+    aliasedMapping = aliasedMapping || {}
+    const aliasedKey = omitNamespace ? key : createNamespace(key)
+    aliasedMapping[aliasedKey] = createNamespace(mapping[key] === true ? aliasedKey : mapping[key])
   }
 
   if (aliasedMapping) {
@@ -61,8 +63,6 @@ export default {
     const omitNamespace = !('omitNamespace' in mapping) || mapping.omitNamespace
 
     for (const type in mapping) {
-      const typeMapping = mapping[type]
-
       let optionKey
       let mapper
 
@@ -71,7 +71,7 @@ export default {
         mapper = mapActions
       } else {
         optionKey = 'computed'
-        mapper = type === 'state' ? mapState : mapGetters
+        mapper = type === 'getters' ? mapGetters : mapState
       }
 
       this.$options[optionKey] = this.$options[optionKey] || {}
@@ -79,7 +79,7 @@ export default {
       assignComponentOption(
         this.$options[optionKey],
         mapper,
-        typeMapping,
+        mapping[type],
         omitNamespace
       )
     }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,4 +1,5 @@
 import { mapState, mapGetters, mapActions } from './helpers'
+import { callIfFunction } from './utils'
 
 function assignComponentOption (option, mapper, mapping, omitNamespace, namespace) {
   const createNamespace = key => `${namespace || ''}${namespace && key ? '/' : ''}${key || ''}`
@@ -55,10 +56,12 @@ function assignComponentOption (option, mapper, mapping, omitNamespace, namespac
 
 export default {
   beforeCreate () {
-    const mapping = this.$options.statorMap
+    let mapping = this.$options.statorMap
     if (!mapping) {
       return
     }
+
+    mapping = callIfFunction(mapping)
 
     const omitNamespace = !('omitNamespace' in mapping) || mapping.omitNamespace
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -71,7 +71,7 @@ export default {
 
     injectStator(Vue, options)
 
-    if (!options || !options.disableMixin) {
+    if (options && options.mixin) {
       Vue.mixin(mixin)
     }
   }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,5 @@
 import { createStore } from './store'
+import mixin from './mixin'
 
 export const injectedPropertyName = 'stator'
 
@@ -69,5 +70,9 @@ export default {
     Vue[installKey] = true
 
     injectStator(Vue, options)
+
+    if (!options || !options.disableMixin) {
+      Vue.mixin(mixin)
+    }
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -168,12 +168,12 @@ export function registerGetters (store, { state, getters: parent }, getters) {
     }
 
     Object.defineProperty(parent, key, {
-      get: () => getters[key](state, store.$getters, store.$state)
+      get: () => getters[key](state, parent, store.$state, store.$getters)
     })
   }
 }
 
-export function registerActions (context, { state, actions: parent }, actions) {
+export function registerActions (context, { state, getters, actions: parent }, actions) {
   if (!actions) {
     return
   }
@@ -184,9 +184,18 @@ export function registerActions (context, { state, actions: parent }, actions) {
       continue
     }
 
+    const ctx = {
+      ...context,
+      state,
+      rootState: context.$state,
+      getters,
+      rootGetters: context.$getters,
+      actions: parent
+    }
+
     // TODO: why no arrow fn here? do we need this context?
     parent[key] = function (...args) {
-      return actions[key](context, state, ...args)
+      return actions[key](ctx, ...args)
     }
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -187,9 +187,7 @@ export function registerActions (context, { state, getters, actions: parent }, a
     const ctx = {
       ...context,
       state,
-      rootState: context.$state,
       getters,
-      rootGetters: context.$getters,
       actions: parent
     }
 

--- a/src/store.js
+++ b/src/store.js
@@ -184,16 +184,14 @@ export function registerActions (context, { state, getters, actions: parent }, a
       continue
     }
 
+    // We dont add the root state here, they can already be accessed through
+    // this.$state and not adding it here is a small perf benefit
     const ctx = {
-      ...context,
       state,
       getters,
       actions: parent
     }
 
-    // TODO: why no arrow fn here? do we need this context?
-    parent[key] = function (...args) {
-      return actions[key](ctx, ...args)
-    }
+    parent[key] = (...args) => actions[key].call(context, ctx, ...args)
   }
 }

--- a/test/e2e/nuxt-ssr.test.js
+++ b/test/e2e/nuxt-ssr.test.js
@@ -47,6 +47,10 @@ describe('basic', () => {
 
     expect(await page.getText('.state')).toBe(nav ? '456' : '123')
     expect(await page.getText('.getter')).toBe('Jonas Galvez')
+
+    expect(await page.stator('$firstInjection')).toBe('first')
+    // expect(await page.stator('$secondInjection')).toBe('second')
+    expect(await page.stator('$axios')).toBeUndefined()
   }
 
   async function testAbout (nav) {

--- a/test/e2e/nuxt-ssr.test.js
+++ b/test/e2e/nuxt-ssr.test.js
@@ -50,7 +50,7 @@ describe('basic', () => {
 
     expect(await page.stator('$firstInjection')).toBe('first')
     // expect(await page.stator('$secondInjection')).toBe('second')
-    expect(await page.stator('$axios')).toBeUndefined()
+    expect(await page.stator('$axios')).toBeFalsy()
   }
 
   async function testAbout (nav) {

--- a/test/fixtures/nuxt-spa/store/user/actions.js
+++ b/test/fixtures/nuxt-spa/store/user/actions.js
@@ -1,3 +1,3 @@
-export function update (_, state, user) {
+export function update ({ state }, user) {
   Object.assign(state, user)
 }

--- a/test/fixtures/nuxt-ssr/nuxt.config.js
+++ b/test/fixtures/nuxt-ssr/nuxt.config.js
@@ -1,7 +1,13 @@
 import { nuxtModulePath, vueStatorPath } from '../../utils/constants'
 
 export default {
-  buildModules: [nuxtModulePath],
+  plugins: ['~/plugins/my-injection'],
+  buildModules: [{
+    src: nuxtModulePath,
+    options: {
+      inject: ['axios', 'firstInjection']
+    }
+  }],
   build: {
     extend (config) {
       config.resolve.alias['vue-stator'] = vueStatorPath

--- a/test/fixtures/nuxt-ssr/plugins/my-injection.js
+++ b/test/fixtures/nuxt-ssr/plugins/my-injection.js
@@ -1,0 +1,7 @@
+export default function myInjection (context, inject) {
+  context.$firstInjection = 'first'
+  inject('firstInjection', 'first')
+
+  context.$secondInjection = 'second'
+  inject('secondInjection', 'second')
+}

--- a/test/fixtures/nuxt-ssr/store/user.js
+++ b/test/fixtures/nuxt-ssr/store/user.js
@@ -1,3 +1,3 @@
-export function update (_, state, user) {
+export function update ({ state }, user) {
   Object.assign(state, user)
 }

--- a/test/fixtures/vue-ssr/App.js
+++ b/test/fixtures/vue-ssr/App.js
@@ -76,7 +76,7 @@ export default function createApp () {
           }
         },
         actions: {
-          update (_, state, user) {
+          update ({ state }, user) {
             Object.assign(state, user)
           }
         }

--- a/test/unit/mixin.test.js
+++ b/test/unit/mixin.test.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { mount, createLocalVue } from '@vue/test-utils'
-import * as helpers from '~/helpers'
 import plugin from '~/plugin'
 
 describe('reactivity', () => {
@@ -57,8 +56,7 @@ describe('reactivity', () => {
         ],
         actions: ['myAction']
       },
-      template: '<p>{{ test }}</p>',
-      computed: helpers.mapState('test')
+      template: '<p>test</p>'
     }
 
     const wrapper = mount(Component, { localVue })
@@ -115,8 +113,7 @@ describe('reactivity', () => {
         },
         getters: ''
       },
-      template: '<p>{{ test }}</p>',
-      computed: helpers.mapState('test')
+      template: '<p>test</p>'
     }
 
     const wrapper = mount(Component, { localVue })

--- a/test/unit/mixin.test.js
+++ b/test/unit/mixin.test.js
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment jsdom
+ */
+import { mount, createLocalVue } from '@vue/test-utils'
+import * as helpers from '~/helpers'
+import plugin from '~/plugin'
+
+describe('reactivity', () => {
+  test('mixin works', () => {
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      mixin: true,
+      state () {
+        return {
+          key: 0,
+          my: {
+            module: {
+              nonAliasedKey: 1,
+              theModuleKey: 2
+            }
+          }
+        }
+      },
+      getters: {
+        rootGetter: () => 3
+      },
+      actions: {
+        myAction: () => 4
+      },
+      modules: {
+        my: {
+          modules: {
+            module: {
+              getters: {
+                myGetter: () => 5
+              }
+            }
+          }
+        }
+      }
+    })
+
+    const Component = {
+      statorMap: {
+        state: {
+          key: false,
+          my: {
+            module: {
+              nonAliasedKey: true,
+              aliasedKey: 'theModuleKey'
+            }
+          }
+        },
+        getters: [
+          'rootGetter',
+          'my/module/myGetter'
+        ],
+        actions: ['myAction']
+      },
+      template: '<p>{{ test }}</p>',
+      computed: helpers.mapState('test')
+    }
+
+    const wrapper = mount(Component, { localVue })
+
+    expect(wrapper.vm.key).toBeUndefined()
+    expect(wrapper.vm.nonAliasedKey).toBe(1)
+    expect(wrapper.vm.theModuleKey).toBeUndefined()
+    expect(wrapper.vm.aliasedKey).toBe(2)
+    expect(wrapper.vm.rootGetter).toBe(3)
+    expect(wrapper.vm['my/module/myGetter']).toBe(5)
+    expect(wrapper.vm.myAction()).toBe(4)
+  })
+
+  test('mixin works', () => {
+    const localVue = createLocalVue()
+
+    localVue.use(plugin, {
+      mixin: true,
+      state () {
+        return {
+          my: {
+            key: 0,
+            module: {
+              nonAliasedKey: 1,
+              theModuleKey: 2
+            }
+          }
+        }
+      },
+      modules: {
+        my: {
+          modules: {
+            module: {
+              getters: {
+                myGetter: () => 5
+              }
+            }
+          }
+        }
+      }
+    })
+
+    const Component = {
+      statorMap: {
+        omitNamespace: false,
+        state: {
+          my: {
+            key: true,
+            module: [
+              'nonAliasedKey',
+              'theModuleKey'
+            ]
+          }
+        },
+        getters: ''
+      },
+      template: '<p>{{ test }}</p>',
+      computed: helpers.mapState('test')
+    }
+
+    const wrapper = mount(Component, { localVue })
+
+    expect(wrapper.vm.key).toBeUndefined()
+    expect(wrapper.vm['my/key']).toBe(0)
+    expect(wrapper.vm.nonAliasedKey).toBeUndefined()
+    expect(wrapper.vm['my/module/nonAliasedKey']).toBe(1)
+    expect(wrapper.vm['my/module/theModuleKey']).toBe(2)
+  })
+})

--- a/test/unit/plugin.test.js
+++ b/test/unit/plugin.test.js
@@ -5,6 +5,7 @@ describe('plugin', () => {
   test('does not install twice', () => {
     class VueTest {}
     VueTest.use = jest.fn()
+    VueTest.mixin = jest.fn()
 
     plugin.install(VueTest)
     expect(VueTest.use).toHaveBeenCalledTimes(1)

--- a/test/unit/plugin.test.js
+++ b/test/unit/plugin.test.js
@@ -2,7 +2,7 @@ import plugin, * as injects from '~/plugin'
 import * as store from '~/store'
 
 describe('plugin', () => {
-  test('does not install twice', () => {
+  test('does not install twice or mixin', () => {
     class VueTest {}
     VueTest.use = jest.fn()
     VueTest.mixin = jest.fn()
@@ -11,6 +11,18 @@ describe('plugin', () => {
     expect(VueTest.use).toHaveBeenCalledTimes(1)
     plugin.install(VueTest)
     expect(VueTest.use).toHaveBeenCalledTimes(1)
+    expect(VueTest.mixin).not.toHaveBeenCalled()
+  })
+
+  test('installs mixin when configured', () => {
+    class VueTest {}
+    VueTest.use = jest.fn()
+    VueTest.mixin = jest.fn()
+
+    plugin.install(VueTest, { mixin: true })
+    expect(VueTest.mixin).toHaveBeenCalledTimes(1)
+    plugin.install(VueTest, { mixin: true })
+    expect(VueTest.mixin).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/test/unit/store.test.js
+++ b/test/unit/store.test.js
@@ -18,7 +18,7 @@ describe('store', () => {
         }
       },
       actions: {
-        setName (_, state, newName) {
+        setName ({ state }, newName) {
           state.name = newName
         }
       }
@@ -68,7 +68,7 @@ describe('store', () => {
             }
           },
           actions: {
-            setName (_, state, newName) {
+            setName ({ state }, newName) {
               state.name = newName
             }
           }
@@ -106,7 +106,7 @@ describe('store', () => {
         }
       },
       actions: {
-        setName (_, state, newName) {
+        setName ({ state }, newName) {
           state.name = newName
         }
       }
@@ -140,7 +140,7 @@ describe('store', () => {
         }
       },
       actions: {
-        setName (_, state, newName) {
+        setName ({ state }, newName) {
           state.name = newName
         }
       }
@@ -199,7 +199,7 @@ describe('store', () => {
         name: 'test'
       },
       actions: {
-        setName (_, state, newName) {
+        setName ({ state }, newName) {
           state.name = newName
         }
       }
@@ -230,10 +230,10 @@ describe('store', () => {
             lastName: 'last'
           },
           actions: {
-            setFirstName (_, state, newName) {
+            setFirstName ({ state }, newName) {
               state.firstName = newName
             },
-            setLastName (_, state, newName) {
+            setLastName ({ state }, newName) {
               state.lastName = newName
             }
           }

--- a/test/utils/browser.js
+++ b/test/utils/browser.js
@@ -52,6 +52,16 @@ export function startBrowser ({ folder, port, globalName = 'nuxt', extendPage = 
             query: window.$nuxt.$route.query
           }))
         },
+        stator (prop) {
+          /* eslint-disable no-console */
+          return page.runScript((prop, globalName) => {
+            const stator = window[globalName].$stator
+            if (prop) {
+              return stator ? stator[prop] : undefined
+            }
+            return stator
+          }, prop, globalName)
+        },
         ...extendPage
       }
     }


### PR DESCRIPTION
The mixin allows you to omit using the mapping methods directly, instead you can define a component property which will add the mapping for you:

The mixin needs to be enabled by providing the `mixin: true` option to the vue-stator plugin
```js
// App.js
Vue.use(VueStator, { mixin: true })

// my-component.vue
<script>
export default {
  statorMap: {
    omitNamespace: true, // this is the default, you only need to set this to false if you dont want to omit the namespace
    state: {
      my: {
        module: {
          nonAliasedKey: true,
          aliasedKey: 'theModuleKey'
        }
    },
    getters: [
      'rootGetter',
      'my/module/myGetter'
    ],
    actions: ['myAction']
  },
  mounted () {
    this.nonAliasedKey
    this.aliasedKey
    this.rootGetter
    this.myGetter
    this.myAction()
  }
}
</script>
```